### PR TITLE
Accept file extension, init from URL

### DIFF
--- a/IceCream.xcodeproj/project.pbxproj
+++ b/IceCream.xcodeproj/project.pbxproj
@@ -199,7 +199,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "EXPANDED_CODE_SIGN_IDENTITY='' /usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/IceCream.xcodeproj/project.pbxproj
+++ b/IceCream.xcodeproj/project.pbxproj
@@ -199,7 +199,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "EXPANDED_CODE_SIGN_IDENTITY='' /usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/IceCream/Classes/CreamAsset.swift
+++ b/IceCream/Classes/CreamAsset.swift
@@ -35,9 +35,10 @@ public class CreamAsset: Object {
     /// Cuz we only store the path of data, so we can't access data by `data` property
     /// So use this method if you want get the data of this object
     public func storedData() -> Data? {
-        let filePath = CreamAsset.creamAssetDefaultURL().appendingPathComponent(uniqueFileName)
         return try! Data(contentsOf: filePath)
     }
+    
+    public lazy var filePath: URL = CreamAsset.creamAssetDefaultURL().appendingPathComponent(uniqueFileName)
     
     func save(data: Data, to path: String) {
         let url = CreamAsset.creamAssetDefaultURL().appendingPathComponent(path)
@@ -50,7 +51,7 @@ public class CreamAsset: Object {
     
     var asset: CKAsset {
         get {
-            let diskCachePath = CreamAsset.creamAssetDefaultURL().appendingPathComponent(uniqueFileName)
+            let diskCachePath = filePath
             let uploadAsset = CKAsset(fileURL: diskCachePath)
             return uploadAsset
         }


### PR DESCRIPTION
For our usage, we need to maintain the file extensions, otherwise our
AVPlayer can't read the .mov files. This allows for maintaining file
extensions by passing one in with the data, or by passing in the URL of
the asset instead of the data.